### PR TITLE
Update installation instructions for v0.3 on Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To get the latest list of Julia packages, run the `Pkg.update()` command:
 julia> Pkg.update()
 ```
 
-As the toolbox is still in development, this package and its dependencies will need to be retrieved manually from this repository. To do so, change directory to the Julia package directory at the command line. This will be located at `~/.julia` for Linux and OS X, or `%APPDATA%/julia/packages` for Windows by default.
+As the toolbox is still in development, this package and its dependencies will need to be retrieved manually from this repository. To do so, change directory to the Julia package directory at the command line. This will be located at `~/.julia/<version>` for Linux and OS X, or `%APPDATA%/julia/packages` for Windows by default.
 
 From the package directory, issue the following command:
 


### PR DESCRIPTION
I am using Version 0.3.11-pre+13 of Julia and using a MacBook Pro.
It looks like the package should be installed in the version folder 
instead of just being placed inside `~/.julia` in order for the `Pkg.update`
to work.
